### PR TITLE
Improve routing, silence webpack-dev-server output

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -14,6 +14,8 @@ module.exports = {
     app: './src/app/index.js', // Start looking for things to bundle/optimize from here. Webpack will look for require/import calls.
   },
   output: {
+    publicPath: '/',
+
     // Put bundled javascript inside the dist folder
     path: path.resolve(process.cwd(), 'dist/'),
     filename: '[name].js',

--- a/config/webpack.development.js
+++ b/config/webpack.development.js
@@ -10,7 +10,8 @@ module.exports = merge(common, {
     historyApiFallback: true,
     contentBase: path.resolve(process.cwd(), 'dist/'),
     compress: true,
-    open: true,
+    open: false,
     port: 8080,
+    stats: 'minimal',
   },
 });

--- a/src/app/components/SiteHeader.vue
+++ b/src/app/components/SiteHeader.vue
@@ -77,7 +77,7 @@ export default {
 
     // Change the URL of the address bar without reloading the page
     changeUrl(group) {
-      window.history.pushState(group, `RoosterRedux | ${group}`, `/${group}`);
+      window.history.pushState(group, `RoosterRedux | ${group}`, `/group/${group}`);
       this.changeTitle(group);
     },
 

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -13,7 +13,7 @@ export default new Router({
       component: HomeView,
       children: [
         {
-          path: '/:group',
+          path: '/group/:group',
           props: true,
         },
       ],


### PR DESCRIPTION
This pull requests fixes the following:

1. Minimise webpack-dev-server output. Most output isn't really relevant. Recently I discovered webpack has a settings to minimise not relevant output.

2. Changes group schedule routes from `/ao3b` to `/group/ao3b`. This prevents error messages that the group doesn't exist when visiting a random url
